### PR TITLE
Redesign database initialization

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -111,7 +111,7 @@ function DB:SetCollectedState(obj, state)
 		rawset(obj, 'collected', true)
 	end
 end
-function DB:Process()
+function DB:Initialize()
 	for modName,mod in pairs(MasterCollector.Modules or {}) do
 		for objType,objTable in pairs(mod.moduleDB) do
 			for id, obj in pairs(objTable) do

--- a/datastructures.lua
+++ b/datastructures.lua
@@ -1,9 +1,5 @@
 local MasterCollector = select(2, ...)
 local L = MasterCollector.L
--- set local functions for blizz API calls for slightly faster processing
-local GetPetInfoBySpeciesID = C_PetJournal.GetPetInfoBySpeciesID
-local GetQuestTitle = QuestUtils_GetQuestName
-local RequestLoadQuestByID = C_QuestLog.RequestLoadQuestByID
 local IsOnQuest = C_QuestLog.IsOnQuest
 
 MasterCollector.playerData = {}
@@ -179,46 +175,6 @@ local function GetQuestTextColor(obj)
 	if obj.repeatable then return colors.blue end
 end
 
--- set a background frame that listens to load requests for quest data
-local QuestNames = setmetatable({}, {
-	__index = function(self, key)
-		if not rawget(self, key) then
-			local name = GetQuestTitle(key)
-			if not name or name=='' then
-				RequestLoadQuestByID(key)
-				rawset(self, key, SEARCH_LOADING_TEXT)
-				return SEARCH_LOADING_TEXT
-			else
-				rawset(self, key, name)
-				return name
-			end
-		else
-			return string.format(L.Text.QUEST_PENDING_NAME, key)
-		end
-	end
-})
-local pendingQuestTitles = CreateFrame("FRAME", 'MasterCollectorQuestTitleQueueFrame', UIParent)
-pendingQuestTitles:RegisterEvent("QUEST_DATA_LOAD_RESULT")
-pendingQuestTitles:SetScript("OnEvent", function(self, event, ...)
-	-- Once blizzard returns the quest data, we can inspect the result to see if it's a valid entry or not
-	-- Quests that have a nil or false "success" return tell us that either blizzard has removed the quest completely OR
-	--   the quest itself doesn't have a name (e.g. tracking quests). 
-	if event == "QUEST_DATA_LOAD_RESULT" and rawget(QuestNames, ...) then -- only bother with results from quest load requests made by this addon
-		local questID, success = ...
-		-- For some reason, Blizzard sends QUEST_DATA_LOAD_RESULT for every step completion in a world quest for all world/bonus quests on the map.
-		-- If the quest already has a name that isn't the loading text, we can skip this event
-		if QuestNames[questID] ~= SEARCH_LOADING_TEXT then return end
-		
-		if success then
-			rawset(QuestNames, questID, GetQuestTitle(questID))
-		else
-			rawset(QuestNames, questID, MasterCollector.L.Quests[questID] or string.format(L.Text.QUEST_PENDING_NAME, questID))
-		end
-		MasterCollector:RefreshWindows(true)
-	end
-end)
-
-
 -- All metatables describing data structures should be added below
 MasterCollector.structs = {}
 MasterCollector.structs.panel = {
@@ -333,15 +289,15 @@ MasterCollector.structs.quest = {
 		elseif key == "eligible" then
 			self.eligible = IsEligible(self)
 		elseif key == "type" then return "quest"
+		elseif key == "name" then return "Quest #"..self.id
 		elseif key == "sortkey" then
-			return QuestNames[self.id]
+			return self.name
 		elseif key == "text" then
 			local color = GetQuestTextColor(self)
-			local name = QuestNames[self.id]
 			if color then
-				return string.format("%s%s|r", color, name)
+				return string.format("%s%s|r", color, self.name)
 			else
-				return name
+				return self.name
 			end
 		elseif key == "collected" then
 			if self.IsMissed and self.IsMissed() then

--- a/datastructures.lua
+++ b/datastructures.lua
@@ -242,14 +242,7 @@ MasterCollector.structs.panel = {
 }
 MasterCollector.structs.ach = {
 	__index = function(self, key)
-		if key == "text" then
-			local name = select(2, GetAchievementInfo(self.id))
-			if name then
-				rawset(self, 'name', format('|cffffff00%s|r', name))
-				return self.name
-			end
-			return format('|cffffff00%s|r', 'Achievement #' .. self.id)
-		elseif key == "eligible" then
+		if key == "eligible" then
 			self.eligible = IsEligible(self)
 		elseif key == "type" then
 			return "achievement"
@@ -257,8 +250,6 @@ MasterCollector.structs.ach = {
 			return determineVisibility(self)
 		elseif key == "collected" then
 			return select(4, GetAchievementInfo(self.id)) -- TODO: setting for track by character, not just account?
-		elseif key == "icon" then
-			return select(10, GetAchievementInfo(self.id)) -- TODO: setting for track by character, not just account?
 		else
 			return rawget(self, key)
 		end
@@ -324,18 +315,12 @@ MasterCollector.structs.npc = {
 }
 MasterCollector.structs.pet = {
 	__index = function(self, key)
-		if not rawget(self, "loaded") then
-			local name, icon, _, npcID = GetPetInfoBySpeciesID(self.id)
-			self.text = name
-			self.npcID = npcID
-			self.icon = icon
-			self.loaded = true
-			self.collected = C_PetJournal.GetNumCollectedInfo(self.id) > 0
-		end
 		if key == "visible" then
 			return determineVisibility(self)
 		elseif key == "eligible" then
 			self.eligible = IsEligible(self)
+		elseif key == 'text' then
+			return 'Pet Species #'..self.id
 		else
 			return rawget(self, key)
 		end
@@ -376,26 +361,6 @@ MasterCollector.structs.quest = {
 			return self.icon
 		elseif key == "repeatable" then
 			return self.flags and (self.flags.daily or self.flags.weekly or self.flags.always or self.flags.annual or self.flags.calling or self.flags.wq)
-		else
-			return rawget(self, key)
-		end
-	end
-}
-MasterCollector.structs.toy = {
-	__index = function(self, key)
-		if key == "visible" then
-			return determineVisibility(self)
-		elseif key == "collected" then
-			return PlayerHasToy(self.id)
-		elseif key == "eligible" then
-			self.eligible = IsEligible(self)
-		elseif key == "text" then
-			local item = Item:CreateFromItemID(self.id)
-			item:ContinueOnItemLoad(function()
-				rawset(self, 'icon', item:GetItemIcon())
-				rawset(self, 'text', item:GetItemName())
-			end)
-			return 'Item #' .. self.id
 		else
 			return rawget(self, key)
 		end

--- a/frame.lua
+++ b/frame.lua
@@ -527,7 +527,9 @@ function Window:Sort()
 		-- sort the current dataSet keys
 		local keys={}
 		for k in pairs(dataSet or {}) do keys[#keys+1]=k end
-		table.sort(keys, function(a,b) return (a and b) and (dataSet[a].sortkey or dataSet[a].text) < (dataSet[b].sortkey or dataSet[b].text) end)
+		table.sort(keys, function(a,b)
+			return (a and b) and (dataSet[a].sortkey or dataSet[a].text or 0) < (dataSet[b].sortkey or dataSet[b].text or 0)
+		end)
 		-- rebuild the data as a sorted set
 		for idx,key in pairs(keys) do
 			sortedSet[idx] = dataSet[key]

--- a/main.lua
+++ b/main.lua
@@ -65,26 +65,30 @@ function MasterCollector:MapData(mapID)
 end
 
 function MasterCollector:Start()
-	MasterCollector.DB:Initialize()
-	
 	local currentZoneWindow = MasterCollector.Window:Get("MasterCollectorCurrentZone")
 	if not currentZoneWindow then
 		currentZoneWindow = MasterCollector.Window:New("MasterCollectorCurrentZone", "currentZone")
-	end
-	currentZoneWindow.displayFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
-	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
-	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED_INDOORS")
-	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED")
-	currentZoneWindow.displayFrame:RegisterEvent("NEW_WMO_CHUNK")
-	currentZoneWindow.displayFrame:SetScript("OnEvent", function(self, event, ...)
-		-- the current zone list should perform the same initial load as it does with zone map changes
-		if event == "PLAYER_ENTERING_WORLD" or "ZONE_CHANGED" or "ZONE_CHANGED_NEW_AREA" or "ZONE_CHANGED_INDOORS" or "NEW_WMO_CHUNK" then
+		currentZoneWindow.Reload = function()
 			local mapID, data = GetCurrentZoneData()
 			if mapID and mapID ~= currentZoneWindow.mapID then
 				currentZoneWindow.mapID = mapID
 				currentZoneWindow:SetTitle(((mapID and C_Map.GetMapInfo(mapID).name) or "UNKNOWN MAP" ) .. ' ('..mapID..')')
 				currentZoneWindow:SetData(data, true)
 			end
+		end
+	end
+	
+	currentZoneWindow.displayFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED_INDOORS")
+	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED")
+	currentZoneWindow.displayFrame:RegisterEvent("NEW_WMO_CHUNK")
+	currentZoneWindow.displayFrame:SetScript("OnEvent", function(self, event, ...)
+		if event == "PLAYER_ENTERING_WORLD" then
+			MasterCollector.DB:EnrichData()
+		end
+		if MasterCollector.Ready and ("ZONE_CHANGED" or "ZONE_CHANGED_NEW_AREA" or "ZONE_CHANGED_INDOORS" or "NEW_WMO_CHUNK") then
+			currentZoneWindow.Reload()
 		end
 	end)
 end

--- a/main.lua
+++ b/main.lua
@@ -85,7 +85,7 @@ function MasterCollector:Start()
 	currentZoneWindow.displayFrame:RegisterEvent("ZONE_CHANGED")
 	currentZoneWindow.displayFrame:RegisterEvent("NEW_WMO_CHUNK")
 	currentZoneWindow.displayFrame:SetScript("OnEvent", function(self, event, ...)
-		if event == "PLAYER_ENTERING_WORLD" then
+		if event == "PLAYER_ENTERING_WORLD" and MasterCollector.DB.EnrichData then
 			MasterCollector.DB:EnrichData()
 		end
 		if MasterCollector.Ready and ("ZONE_CHANGED" or "ZONE_CHANGED_NEW_AREA" or "ZONE_CHANGED_INDOORS" or "NEW_WMO_CHUNK") then

--- a/main.lua
+++ b/main.lua
@@ -65,9 +65,8 @@ function MasterCollector:MapData(mapID)
 end
 
 function MasterCollector:Start()
-	-- initialize the database(s)
-	MasterCollector.DB:Process()
-
+	MasterCollector.DB:Initialize()
+	
 	local currentZoneWindow = MasterCollector.Window:Get("MasterCollectorCurrentZone")
 	if not currentZoneWindow then
 		currentZoneWindow = MasterCollector.Window:New("MasterCollectorCurrentZone", "currentZone")

--- a/main.lua
+++ b/main.lua
@@ -74,6 +74,7 @@ function MasterCollector:Start()
 				currentZoneWindow.mapID = mapID
 				currentZoneWindow:SetTitle(((mapID and C_Map.GetMapInfo(mapID).name) or "UNKNOWN MAP" ) .. ' ('..mapID..')')
 				currentZoneWindow:SetData(data, true)
+				currentZoneWindow:Refresh()
 			end
 		end
 	end

--- a/modManager.lua
+++ b/modManager.lua
@@ -128,11 +128,12 @@ events.ADDON_LOADED = function(loadedAddonName)
 		
 		local  completedQuestIDs = C_QuestLog.GetAllCompletedQuestIDs()
 		for _,v in pairs(completedQuestIDs) do
-			quest = MasterCollector.DB:GetObjectData("quest", v)
-			MasterCollector.DB:SetCollectedState(quest, true)
+			local quest = MasterCollector.DB:GetObjectData("quest", v)
+			if quest then quest.collected = true end
 		end
 		
 		MasterCollector:InitializeSettings()
+		MasterCollector.DB:Initialize()
 		MasterCollector:Start()
 	end
 end


### PR DESCRIPTION
Runtime performance was heavily impacted by ad-hoc loading on zone/chunk change but would simultaneously increase loading screens based on how many entities there were to load. For example, Valdrakken could take anywhere between 8 and 15 seconds longer to load. With this refactor, database enrichment now happens after the player logs in and is spread out at runtime. While it creates a bit of latency, it subsides quickly and the remainder of the runtime is smooth.